### PR TITLE
Plugin manager

### DIFF
--- a/data/client/king_phisher/client_config.json
+++ b/data/client/king_phisher/client_config.json
@@ -12,6 +12,9 @@
   "filter.campaign.user": true,
   "filter.campaign.other_users": false,
   "plugins": {},
+  "plugins.catalogs": [
+    "https://raw.githubusercontent.com/securestate/king-phisher-plugins/master/catalog.json"
+  ],
   "plugins.enabled": [],
   "plugins.installed": {},
   "rpc.serializer": null,

--- a/data/client/king_phisher/client_config.json
+++ b/data/client/king_phisher/client_config.json
@@ -13,6 +13,7 @@
   "filter.campaign.other_users": false,
   "plugins": {},
   "plugins.enabled": [],
+  "plugins.installed": {},
   "rpc.serializer": null,
   "server": "localhost:22",
   "server_remote_port": 80,

--- a/data/client/king_phisher/client_config.json
+++ b/data/client/king_phisher/client_config.json
@@ -1,4 +1,7 @@
 {
+  "catalogs": [
+    "https://raw.githubusercontent.com/securestate/king-phisher-plugins/master/catalog.json"
+  ],
   "dashboard.bottom": "VisitsTimeline",
   "dashboard.top_left": "Overview",
   "dashboard.top_right": "VisitorInfo",
@@ -12,9 +15,6 @@
   "filter.campaign.user": true,
   "filter.campaign.other_users": false,
   "plugins": {},
-  "plugins.catalogs": [
-    "https://raw.githubusercontent.com/securestate/king-phisher-plugins/master/catalog.json"
-  ],
   "plugins.enabled": [],
   "plugins.installed": {},
   "rpc.serializer": null,

--- a/data/client/king_phisher/king-phisher-client.ui
+++ b/data/client/king_phisher/king-phisher-client.ui
@@ -2761,12 +2761,12 @@ Spencer McIntyre</property>
               </packing>
             </child>
             <child>
-              <object class="GtkExpander" id="PluginManagerWindow.expander_plugin_info">
+              <object class="GtkExpander" id="PluginManagerWindow.expander_info">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <signal name="activate" handler="signal_expander_activate" swapped="no"/>
                 <child>
-                  <object class="GtkScrolledWindow" id="PluginManagerWindow.scrolledwindow_plugin_info">
+                  <object class="GtkScrolledWindow" id="PluginManagerWindow.scrolledwindow_info">
                     <property name="height_request">125</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
@@ -2774,11 +2774,11 @@ Spencer McIntyre</property>
                     <property name="border_width">3</property>
                     <property name="shadow_type">in</property>
                     <child>
-                      <object class="GtkViewport" id="PluginManagerWindow.viewport_plugin_info">
+                      <object class="GtkViewport" id="PluginManagerWindow.viewport_info">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <child>
-                          <object class="GtkStack" id="PluginManagerWindow.stack_plugin_info">
+                          <object class="GtkStack" id="PluginManagerWindow.stack_info">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <child>
@@ -2974,6 +2974,122 @@ Spencer McIntyre</property>
                                 <property name="name">page1</property>
                                 <property name="title" translatable="yes">page1</property>
                                 <property name="position">1</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkGrid" id="PluginManagerWindow.grid_catalog_repo_info">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="row_spacing">3</property>
+                                <property name="column_spacing">3</property>
+                                <property name="column_homogeneous">True</property>
+                                <child>
+                                  <object class="GtkLabel" id="PluginManagerWindow.label_catalog_repo_info_title">
+                                    <property name="visible">True</property>
+                                    <property name="sensitive">False</property>
+                                    <property name="can_focus">False</property>
+                                    <attributes>
+                                      <attribute name="weight" value="bold"/>
+                                      <attribute name="scale" value="1.25"/>
+                                    </attributes>
+                                  </object>
+                                  <packing>
+                                    <property name="left_attach">0</property>
+                                    <property name="top_attach">0</property>
+                                    <property name="width">4</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel" id="PluginManagerWindow.label_catalog_repo_info_for_maintainers">
+                                    <property name="visible">True</property>
+                                    <property name="sensitive">False</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="halign">end</property>
+                                    <property name="valign">start</property>
+                                    <property name="label" translatable="yes">Maintainers:</property>
+                                    <attributes>
+                                      <attribute name="scale" value="0.90000000000000002"/>
+                                    </attributes>
+                                  </object>
+                                  <packing>
+                                    <property name="left_attach">0</property>
+                                    <property name="top_attach">1</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel" id="PluginManagerWindow.label_catalog_repo_info_maintainers">
+                                    <property name="visible">True</property>
+                                    <property name="sensitive">False</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="tooltip_text" translatable="yes">The contributors who have written and provided this plugin.</property>
+                                    <property name="halign">start</property>
+                                    <property name="valign">start</property>
+                                    <attributes>
+                                      <attribute name="scale" value="0.90000000000000002"/>
+                                    </attributes>
+                                  </object>
+                                  <packing>
+                                    <property name="left_attach">1</property>
+                                    <property name="top_attach">1</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel" id="PluginManagerWindow.label_catalog_repo_info_for_description">
+                                    <property name="visible">True</property>
+                                    <property name="sensitive">False</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="halign">end</property>
+                                    <property name="valign">start</property>
+                                    <property name="label" translatable="yes">Description:</property>
+                                    <attributes>
+                                      <attribute name="scale" value="0.90000000000000002"/>
+                                    </attributes>
+                                  </object>
+                                  <packing>
+                                    <property name="left_attach">0</property>
+                                    <property name="top_attach">2</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel" id="PluginManagerWindow.label_catalog_repo_info_description">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="tooltip_text" translatable="yes">The description of this plugin and the features it provides.</property>
+                                    <property name="halign">start</property>
+                                    <property name="valign">start</property>
+                                    <property name="wrap">True</property>
+                                    <property name="selectable">True</property>
+                                    <attributes>
+                                      <attribute name="scale" value="0.90000000000000002"/>
+                                    </attributes>
+                                  </object>
+                                  <packing>
+                                    <property name="left_attach">1</property>
+                                    <property name="top_attach">2</property>
+                                    <property name="width">3</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel" id="PluginManagerWindow.label_catalog_repo_info_homepage">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">True</property>
+                                    <property name="label" translatable="yes">&lt;a href=""&gt;Homepage&lt;/a&gt;</property>
+                                    <property name="use_markup">True</property>
+                                    <property name="track_visited_links">False</property>
+                                  </object>
+                                  <packing>
+                                    <property name="left_attach">2</property>
+                                    <property name="top_attach">1</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="name">page2</property>
+                                <property name="title" translatable="yes">page2</property>
+                                <property name="position">2</property>
                               </packing>
                             </child>
                           </object>

--- a/data/client/king_phisher/king-phisher-client.ui
+++ b/data/client/king_phisher/king-phisher-client.ui
@@ -2726,6 +2726,7 @@ Spencer McIntyre</property>
     <property name="title" translatable="yes">Plugin Manager</property>
     <property name="window_position">center-on-parent</property>
     <property name="destroy_with_parent">True</property>
+    <signal name="destroy-event" handler="signal_destory" swapped="no"/>
     <child>
       <object class="GtkBox" id="PluginManagerWindow.box">
         <property name="visible">True</property>

--- a/data/client/king_phisher/king-phisher-client.ui
+++ b/data/client/king_phisher/king-phisher-client.ui
@@ -3002,7 +3002,7 @@ Spencer McIntyre</property>
           </packing>
         </child>
         <child>
-          <object class="GtkStatusbar" id="PluginManagerWindow.status_bar">
+          <object class="GtkStatusbar" id="PluginManagerWindow.statusbar">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="tooltip_text" translatable="yes">Current Status</property>

--- a/data/client/king_phisher/king-phisher-client.ui
+++ b/data/client/king_phisher/king-phisher-client.ui
@@ -2719,274 +2719,306 @@ Spencer McIntyre</property>
     </data>
   </object>
   <object class="GtkApplicationWindow" id="PluginManagerWindow">
-    <property name="width_request">550</property>
-    <property name="height_request">300</property>
+    <property name="width_request">700</property>
+    <property name="height_request">400</property>
     <property name="can_focus">False</property>
     <property name="border_width">5</property>
     <property name="title" translatable="yes">Plugin Manager</property>
     <property name="window_position">center-on-parent</property>
     <property name="destroy_with_parent">True</property>
     <child>
-      <object class="GtkPaned" id="PluginManagerWindow.paned_plugins">
+      <object class="GtkBox" id="PluginManagerWindow.box">
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
+        <property name="can_focus">False</property>
         <property name="orientation">vertical</property>
-        <signal name="button-press-event" handler="signal_paned_button_press_event" swapped="no"/>
         <child>
-          <object class="GtkScrolledWindow" id="PluginManagerWindow.scrolledwindow_plugins">
+          <object class="GtkPaned" id="PluginManagerWindow.paned_plugins">
             <property name="visible">True</property>
             <property name="can_focus">True</property>
-            <property name="shadow_type">in</property>
+            <property name="orientation">vertical</property>
+            <signal name="button-press-event" handler="signal_paned_button_press_event" swapped="no"/>
             <child>
-              <object class="GtkTreeView" id="PluginManagerWindow.treeview_plugins">
+              <object class="GtkScrolledWindow" id="PluginManagerWindow.scrolledwindow_plugins">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
-                <property name="activate_on_single_click">True</property>
-                <signal name="row-activated" handler="signal_treeview_row_activated" swapped="no"/>
-                <child internal-child="selection">
-                  <object class="GtkTreeSelection" id="PluginManagerWindow.treeview_plugins.treeselection_campaigns"/>
-                </child>
-              </object>
-            </child>
-          </object>
-          <packing>
-            <property name="resize">True</property>
-            <property name="shrink">False</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkExpander" id="PluginManagerWindow.expander_plugin_info">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <signal name="activate" handler="signal_expander_activate" swapped="no"/>
-            <child>
-              <object class="GtkScrolledWindow" id="PluginManagerWindow.scrolledwindow_plugin_info">
-                <property name="height_request">125</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="vexpand">True</property>
-                <property name="border_width">3</property>
                 <property name="shadow_type">in</property>
                 <child>
-                  <object class="GtkViewport" id="PluginManagerWindow.viewport_plugin_info">
+                  <object class="GtkTreeView" id="PluginManagerWindow.treeview_plugins">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can_focus">True</property>
+                    <property name="activate_on_single_click">True</property>
+                    <signal name="row-activated" handler="signal_treeview_row_activated" swapped="no"/>
+                    <child internal-child="selection">
+                      <object class="GtkTreeSelection" id="PluginManagerWindow.treeview_plugins.treeselection_campaigns"/>
+                    </child>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="resize">True</property>
+                <property name="shrink">False</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkExpander" id="PluginManagerWindow.expander_plugin_info">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <signal name="activate" handler="signal_expander_activate" swapped="no"/>
+                <child>
+                  <object class="GtkScrolledWindow" id="PluginManagerWindow.scrolledwindow_plugin_info">
+                    <property name="height_request">125</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="vexpand">True</property>
+                    <property name="border_width">3</property>
+                    <property name="shadow_type">in</property>
                     <child>
-                      <object class="GtkStack" id="PluginManagerWindow.stack_plugin_info">
+                      <object class="GtkViewport" id="PluginManagerWindow.viewport_plugin_info">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <child>
-                          <object class="GtkGrid" id="PluginManagerWindow.grid_plugin_info">
+                          <object class="GtkStack" id="PluginManagerWindow.stack_plugin_info">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="row_spacing">3</property>
-                            <property name="column_spacing">3</property>
-                            <property name="column_homogeneous">True</property>
                             <child>
-                              <object class="GtkLabel" id="PluginManagerWindow.label_plugin_info_title">
-                                <property name="visible">True</property>
-                                <property name="sensitive">False</property>
-                                <property name="can_focus">False</property>
-                                <attributes>
-                                  <attribute name="weight" value="bold"/>
-                                  <attribute name="scale" value="1.25"/>
-                                </attributes>
-                              </object>
-                              <packing>
-                                <property name="left_attach">0</property>
-                                <property name="top_attach">0</property>
-                                <property name="width">4</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="PluginManagerWindow.label_plugin_info_for_authors">
-                                <property name="visible">True</property>
-                                <property name="sensitive">False</property>
-                                <property name="can_focus">False</property>
-                                <property name="halign">end</property>
-                                <property name="valign">start</property>
-                                <property name="label" translatable="yes">Authors:</property>
-                                <attributes>
-                                  <attribute name="scale" value="0.90000000000000002"/>
-                                </attributes>
-                              </object>
-                              <packing>
-                                <property name="left_attach">0</property>
-                                <property name="top_attach">2</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="PluginManagerWindow.label_plugin_info_authors">
-                                <property name="visible">True</property>
-                                <property name="sensitive">False</property>
-                                <property name="can_focus">False</property>
-                                <property name="tooltip_text" translatable="yes">The contributors who have written and provided this plugin.</property>
-                                <property name="halign">start</property>
-                                <property name="valign">start</property>
-                                <attributes>
-                                  <attribute name="scale" value="0.90000000000000002"/>
-                                </attributes>
-                              </object>
-                              <packing>
-                                <property name="left_attach">1</property>
-                                <property name="top_attach">2</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="PluginManagerWindow.label_plugin_info_version">
-                                <property name="visible">True</property>
-                                <property name="sensitive">False</property>
-                                <property name="can_focus">False</property>
-                                <property name="tooltip_text" translatable="yes">The version identifier of this plugin.</property>
-                                <property name="halign">start</property>
-                                <property name="valign">start</property>
-                                <attributes>
-                                  <attribute name="scale" value="0.90000000000000002"/>
-                                </attributes>
-                              </object>
-                              <packing>
-                                <property name="left_attach">3</property>
-                                <property name="top_attach">1</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="PluginManagerWindow.label_plugin_info_for_description">
-                                <property name="visible">True</property>
-                                <property name="sensitive">False</property>
-                                <property name="can_focus">False</property>
-                                <property name="halign">end</property>
-                                <property name="valign">start</property>
-                                <property name="label" translatable="yes">Description:</property>
-                                <attributes>
-                                  <attribute name="scale" value="0.90000000000000002"/>
-                                </attributes>
-                              </object>
-                              <packing>
-                                <property name="left_attach">0</property>
-                                <property name="top_attach">3</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="PluginManagerWindow.label_plugin_info_description">
+                              <object class="GtkGrid" id="PluginManagerWindow.grid_plugin_info">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="tooltip_text" translatable="yes">The description of this plugin and the features it provides.</property>
-                                <property name="halign">start</property>
-                                <property name="valign">start</property>
-                                <property name="wrap">True</property>
-                                <property name="selectable">True</property>
-                                <attributes>
-                                  <attribute name="scale" value="0.90000000000000002"/>
-                                </attributes>
-                              </object>
-                              <packing>
-                                <property name="left_attach">1</property>
-                                <property name="top_attach">3</property>
-                                <property name="width">3</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="PluginManagerWindow.label_plugin_info_for_version">
-                                <property name="visible">True</property>
-                                <property name="sensitive">False</property>
-                                <property name="can_focus">False</property>
-                                <property name="halign">end</property>
-                                <property name="valign">start</property>
-                                <property name="label" translatable="yes">Version:</property>
-                                <attributes>
-                                  <attribute name="scale" value="0.90000000000000002"/>
-                                </attributes>
-                              </object>
-                              <packing>
-                                <property name="left_attach">2</property>
-                                <property name="top_attach">1</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="PluginManagerWindow.label_plugin_info_compatible">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="tooltip_text" translatable="yes">Whether or not this plugin is compatible with this environment.</property>
-                                <property name="halign">start</property>
-                                <property name="valign">start</property>
-                              </object>
-                              <packing>
-                                <property name="left_attach">1</property>
-                                <property name="top_attach">1</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="PluginManagerWindow.label_plugin_info_homepage">
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="label" translatable="yes">&lt;a href=""&gt;Homepage&lt;/a&gt;</property>
-                                <property name="use_markup">True</property>
-                                <property name="track_visited_links">False</property>
-                                <signal name="activate-link" handler="signal_label_activate_link" swapped="no"/>
-                              </object>
-                              <packing>
-                                <property name="left_attach">2</property>
-                                <property name="top_attach">2</property>
-                                <property name="width">2</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkEventBox" id="PluginManagerWindow.eventbox_plugin_info_for_compatible">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <signal name="button-press-event" handler="signal_eventbox_button_press" swapped="no"/>
+                                <property name="row_spacing">3</property>
+                                <property name="column_spacing">3</property>
+                                <property name="column_homogeneous">True</property>
                                 <child>
-                                  <object class="GtkLabel" id="PluginManagerWindow.label_plugin_info_for_compatible">
+                                  <object class="GtkLabel" id="PluginManagerWindow.label_plugin_info_title">
                                     <property name="visible">True</property>
+                                    <property name="sensitive">False</property>
+                                    <property name="can_focus">False</property>
+                                    <attributes>
+                                      <attribute name="weight" value="bold"/>
+                                      <attribute name="scale" value="1.25"/>
+                                    </attributes>
+                                  </object>
+                                  <packing>
+                                    <property name="left_attach">0</property>
+                                    <property name="top_attach">0</property>
+                                    <property name="width">4</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel" id="PluginManagerWindow.label_plugin_info_for_authors">
+                                    <property name="visible">True</property>
+                                    <property name="sensitive">False</property>
                                     <property name="can_focus">False</property>
                                     <property name="halign">end</property>
                                     <property name="valign">start</property>
-                                    <property name="label" translatable="yes">Compatible:</property>
+                                    <property name="label" translatable="yes">Authors:</property>
                                     <attributes>
-                                      <attribute name="underline" value="True"/>
+                                      <attribute name="scale" value="0.90000000000000002"/>
                                     </attributes>
                                   </object>
+                                  <packing>
+                                    <property name="left_attach">0</property>
+                                    <property name="top_attach">2</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel" id="PluginManagerWindow.label_plugin_info_authors">
+                                    <property name="visible">True</property>
+                                    <property name="sensitive">False</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="tooltip_text" translatable="yes">The contributors who have written and provided this plugin.</property>
+                                    <property name="halign">start</property>
+                                    <property name="valign">start</property>
+                                    <attributes>
+                                      <attribute name="scale" value="0.90000000000000002"/>
+                                    </attributes>
+                                  </object>
+                                  <packing>
+                                    <property name="left_attach">1</property>
+                                    <property name="top_attach">2</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel" id="PluginManagerWindow.label_plugin_info_version">
+                                    <property name="visible">True</property>
+                                    <property name="sensitive">False</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="tooltip_text" translatable="yes">The version identifier of this plugin.</property>
+                                    <property name="halign">start</property>
+                                    <property name="valign">start</property>
+                                    <attributes>
+                                      <attribute name="scale" value="0.90000000000000002"/>
+                                    </attributes>
+                                  </object>
+                                  <packing>
+                                    <property name="left_attach">3</property>
+                                    <property name="top_attach">1</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel" id="PluginManagerWindow.label_plugin_info_for_description">
+                                    <property name="visible">True</property>
+                                    <property name="sensitive">False</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="halign">end</property>
+                                    <property name="valign">start</property>
+                                    <property name="label" translatable="yes">Description:</property>
+                                    <attributes>
+                                      <attribute name="scale" value="0.90000000000000002"/>
+                                    </attributes>
+                                  </object>
+                                  <packing>
+                                    <property name="left_attach">0</property>
+                                    <property name="top_attach">3</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel" id="PluginManagerWindow.label_plugin_info_description">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="tooltip_text" translatable="yes">The description of this plugin and the features it provides.</property>
+                                    <property name="halign">start</property>
+                                    <property name="valign">start</property>
+                                    <property name="wrap">True</property>
+                                    <property name="selectable">True</property>
+                                    <attributes>
+                                      <attribute name="scale" value="0.90000000000000002"/>
+                                    </attributes>
+                                  </object>
+                                  <packing>
+                                    <property name="left_attach">1</property>
+                                    <property name="top_attach">3</property>
+                                    <property name="width">3</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel" id="PluginManagerWindow.label_plugin_info_for_version">
+                                    <property name="visible">True</property>
+                                    <property name="sensitive">False</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="halign">end</property>
+                                    <property name="valign">start</property>
+                                    <property name="label" translatable="yes">Version:</property>
+                                    <attributes>
+                                      <attribute name="scale" value="0.90000000000000002"/>
+                                    </attributes>
+                                  </object>
+                                  <packing>
+                                    <property name="left_attach">2</property>
+                                    <property name="top_attach">1</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel" id="PluginManagerWindow.label_plugin_info_compatible">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="tooltip_text" translatable="yes">Whether or not this plugin is compatible with this environment.</property>
+                                    <property name="halign">start</property>
+                                    <property name="valign">start</property>
+                                  </object>
+                                  <packing>
+                                    <property name="left_attach">1</property>
+                                    <property name="top_attach">1</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel" id="PluginManagerWindow.label_plugin_info_homepage">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">True</property>
+                                    <property name="label" translatable="yes">&lt;a href=""&gt;Homepage&lt;/a&gt;</property>
+                                    <property name="use_markup">True</property>
+                                    <property name="track_visited_links">False</property>
+                                    <signal name="activate-link" handler="signal_label_activate_link" swapped="no"/>
+                                  </object>
+                                  <packing>
+                                    <property name="left_attach">2</property>
+                                    <property name="top_attach">2</property>
+                                    <property name="width">2</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkEventBox" id="PluginManagerWindow.eventbox_plugin_info_for_compatible">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <signal name="button-press-event" handler="signal_eventbox_button_press" swapped="no"/>
+                                    <child>
+                                      <object class="GtkLabel" id="PluginManagerWindow.label_plugin_info_for_compatible">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="halign">end</property>
+                                        <property name="valign">start</property>
+                                        <property name="label" translatable="yes">Compatible:</property>
+                                        <attributes>
+                                          <attribute name="underline" value="True"/>
+                                        </attributes>
+                                      </object>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="left_attach">0</property>
+                                    <property name="top_attach">1</property>
+                                  </packing>
                                 </child>
                               </object>
                               <packing>
-                                <property name="left_attach">0</property>
-                                <property name="top_attach">1</property>
+                                <property name="name">page0</property>
+                                <property name="title" translatable="yes">page0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkTextView" id="PluginManagerWindow.textview_plugin_info">
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                              </object>
+                              <packing>
+                                <property name="name">page1</property>
+                                <property name="title" translatable="yes">page1</property>
+                                <property name="position">1</property>
                               </packing>
                             </child>
                           </object>
-                          <packing>
-                            <property name="name">page0</property>
-                            <property name="title" translatable="yes">page0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkTextView" id="PluginManagerWindow.textview_plugin_info">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                          </object>
-                          <packing>
-                            <property name="name">page1</property>
-                            <property name="title" translatable="yes">page1</property>
-                            <property name="position">1</property>
-                          </packing>
                         </child>
                       </object>
                     </child>
                   </object>
                 </child>
+                <child type="label">
+                  <object class="GtkLabel" id="PluginManagerWindow.label_plugin_info">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">Information</property>
+                  </object>
+                </child>
               </object>
-            </child>
-            <child type="label">
-              <object class="GtkLabel" id="PluginManagerWindow.label_plugin_info">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Plugin Information</property>
-              </object>
+              <packing>
+                <property name="resize">False</property>
+                <property name="shrink">False</property>
+              </packing>
             </child>
           </object>
           <packing>
-            <property name="resize">False</property>
-            <property name="shrink">False</property>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkStatusbar" id="PluginManagerWindow.status_bar">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="tooltip_text" translatable="yes">Current Status</property>
+            <property name="margin_left">10</property>
+            <property name="margin_right">10</property>
+            <property name="margin_start">10</property>
+            <property name="margin_end">10</property>
+            <property name="margin_top">6</property>
+            <property name="margin_bottom">6</property>
+            <property name="orientation">vertical</property>
+            <property name="spacing">2</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
           </packing>
         </child>
       </object>

--- a/king_phisher/catalog.py
+++ b/king_phisher/catalog.py
@@ -354,29 +354,31 @@ class CatalogManager(object):
 	"""
 	def __init__(self, url_catalog=None):
 		self.catalogs = {}
-
 		if url_catalog:
 			self.add_catalog_url(url_catalog)
 
 	def catalog_ids(self):
 		"""
 		The key names of the catalogs in the manager
+
 		:return: the catalogs ids in CatalogManager
-		:rtype: list
+		:rtype: dict_keys
 		"""
 		return self.catalogs.keys()
 
 	def get_repositories(self, catalog_id):
 		"""
 		Returns a list of repositories from the requested catalog
+
 		:param str catalog_id: The name of the catalog in which to get names of repositories from
-		:return: list
+		:return: tuple
 		"""
-		return [repository for repository in self.catalogs[catalog_id].repositories]
+		return self.catalogs[catalog_id].repositories
 
 	def get_repository(self, catalog_id, repo_id):
 		"""
 		Returns the requested repository instance
+
 		:param str catalog_id: The name of the catalog the repo belongs to
 		:param str repo_id: The id of the repository requested.
 		:return: The repository instance

--- a/king_phisher/catalog.py
+++ b/king_phisher/catalog.py
@@ -361,7 +361,8 @@ class CatalogManager(object):
 	def catalog_ids(self):
 		"""
 		The key names of the catalogs in the manager
-		:return: list
+		:return: the catalogs ids in CatalogManager
+		:rtype: list
 		"""
 		return self.catalogs.keys()
 
@@ -377,7 +378,7 @@ class CatalogManager(object):
 		"""
 		Returns the requested repository instance
 		:param str catalog_id: The name of the catalog the repo belongs to
-		:param str repo_id: The title of the repository requested.
+		:param str repo_id: The id of the repository requested.
 		:return: The repository instance
 		:rtype:py:class:Repository
 		"""
@@ -387,8 +388,11 @@ class CatalogManager(object):
 			return repo
 
 	def add_catalog_url(self, url):
-		c = Catalog.from_url(url)
-		self.catalogs[c.id] = Catalog.from_url(url)
+		try:
+			c = Catalog.from_url(url)
+			self.catalogs[c.id] = c
+		except Exception as error:
+			logging.warning("failed to load catalog from url {} due to {}".format(url, error))
 
 def sign_item_files(local_path, signing_key, signing_key_id, repo_path=None):
 	"""

--- a/king_phisher/catalog.py
+++ b/king_phisher/catalog.py
@@ -366,7 +366,7 @@ class CatalogManager(object):
 		"""
 		return self.catalogs.keys()
 
-	def get_repos(self, catalog_id):
+	def get_repositories(self, catalog_id):
 		"""
 		Returns a list of repositories from the requested catalog
 		:param str catalog_id: The name of the catalog in which to get names of repositories from
@@ -374,7 +374,7 @@ class CatalogManager(object):
 		"""
 		return [repository for repository in self.catalogs[catalog_id].repositories]
 
-	def get_repo(self, catalog_id, repo_id):
+	def get_repository(self, catalog_id, repo_id):
 		"""
 		Returns the requested repository instance
 		:param str catalog_id: The name of the catalog the repo belongs to

--- a/king_phisher/catalog.py
+++ b/king_phisher/catalog.py
@@ -377,11 +377,19 @@ class CatalogManager(object):
 		return tuple(self.catalogs[catalog_id].repositories.values())
 
 	def add_catalog_url(self, url):
+		"""
+		Adds catalog to the manager by its url.
+		:param url: url of the catalog which to load
+		:return: The catalog
+		:rtype: :py:class: `.Catalog`
+		"""
 		try:
-			c = Catalog.from_url(url)
-			self.catalogs[c.id] = c
+			catalog = Catalog.from_url(url)
+			self.catalogs[catalog.id] = catalog
 		except Exception as error:
-			self.logger.warning("failed to load catalog from url {0} due to {1}".format(url, error), exc_info=True)
+			self.logger.warning("failed to load catalog from url {0} due to {1}".format(url, error))
+			return
+		return catalog
 
 def sign_item_files(local_path, signing_key, signing_key_id, repo_path=None):
 	"""

--- a/king_phisher/client/plugins.py
+++ b/king_phisher/client/plugins.py
@@ -36,6 +36,7 @@ import tempfile
 import weakref
 
 from king_phisher import plugins
+from king_phisher import catalog
 from king_phisher.client import gui_utilities
 from king_phisher.client import mailer
 from king_phisher.client.widget import extras
@@ -543,3 +544,28 @@ class ClientPluginManager(plugins.PluginManagerBase):
 	_plugin_klass = ClientPlugin
 	def __init__(self, path, application):
 		super(ClientPluginManager, self).__init__(path, (application,))
+
+class PluginCatalogManager(catalog.CatalogManager):
+	"""
+	Base manager for handling Catalogs
+	"""
+	def __init__(self, plugin_type, *args, **kwargs):
+		super(PluginCatalogManager, self).__init__(*args, **kwargs)
+		self.manager_type = 'plugins/' + plugin_type
+
+	def get_collection(self, catalog_id, repo_id):
+		"""
+		Returns the manager type of the plugin collection of the requested catalog and repository.
+
+		:param str catalog_id: The name of the catalog the repo belongs to
+		:param repo_id: The id of the repository requested.
+		:return: The the collection of manager type from the specified catalog and repository.
+		:rtype:py:class:
+		"""
+		if self.manager_type not in self.get_repo(catalog_id, repo_id).collections:
+			self.logger.warning('no plugins/client collection found in {}:{}'.format(catalog_id, repo_id))
+			return
+		return self.get_repo(catalog_id, repo_id).collections[self.manager_type]
+
+	def install_plugin(self, catalog_id, repo_id, plugin_id, install_path):
+		self.get_repo(catalog_id, repo_id).get_item_files(self.manager_type, plugin_id, install_path)

--- a/king_phisher/client/plugins.py
+++ b/king_phisher/client/plugins.py
@@ -29,28 +29,31 @@
 #  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-import distutils.version
+
 import collections
 import json
 import os
+import sys
 import tempfile
 import weakref
-import pip
 
 from king_phisher import plugins
 from king_phisher import catalog
-from king_phisher import version
 from king_phisher.client import gui_utilities
 from king_phisher.client import mailer
 from king_phisher.client.widget import extras
+from king_phisher.plugins import Requirements
 
 from gi.repository import Gtk
 import jinja2.exceptions
 from gi.repository import GLib
 
-DEFAULT_CONFIG_PATH = os.path.join(GLib.get_user_config_dir(), 'king-phisher')
+if sys.version_info[:3] >= (3, 3, 0):
+	_MutableMapping = collections.abc.MutableMapping
+else:
+	_MutableMapping = collections.MutableMapping
 
-StrictVersion = distutils.version.StrictVersion
+DEFAULT_CONFIG_PATH = os.path.join(GLib.get_user_config_dir(), 'king-phisher')
 
 def _split_menu_path(menu_path):
 	menu_path = [path_item.strip() for path_item in menu_path.split('>')]
@@ -553,79 +556,15 @@ class ClientPluginManager(plugins.PluginManagerBase):
 	def __init__(self, path, application):
 		super(ClientPluginManager, self).__init__(path, (application,))
 
-class RepoCache(object):
-	"""
-	RepoCache is used to hold basic information on repos that is to be cached, or pulled from cache.
-	"""
-	__slots__ = ('_id', 'title', 'collections_types', 'url')
-
-	def __init__(self, _id, title, collections_types, url):
-		self._id = _id
-		self.title = title
-		self.collections_types = collections_types
-		self.url = url
-
-	@property
-	def id(self):
-		return self._id
-
-	@property
-	def collections(self):
-		return self.collections_types
-
-	def to_dict(self):
-		repo_cache_values = {
-			'id': self._id,
-			'title': self.title,
-			'collections': self.collections_types,
-			'url': self.url
-		}
-		return repo_cache_values
-
-class CatalogCache(object):
-	"""
-	CatalogCache is used to hold basic information on catalogs that is to be cached or pulled from cache.
-	"""
-	__slots__ = ('_id', 'repos')
-
-	def __init__(self, _id, repos):
-		self._id = _id
-		self.repos = {}
-		for repo in repos:
-			self.repos[repo['id']] = RepoCache(
-				repo['id'],
-				repo['title'],
-				repo['collections'],
-				repo['url']
-			)
-
-	def __getitem__(self, key):
-		return self.repos[key]
-
-	def __iter__(self):
-		for repo in self.repos:
-			yield self.repos[repo]
-
-	@property
-	def id(self):
-		return self._id
-
-	def to_dict(self):
-		catalog_cache_dict = {
-			'id': self._id,
-			'repos': [self.repos[repo].to_dict() for repo in self.repos]
-		}
-		return catalog_cache_dict
-
-class CatalogCacheManager(collections.MutableMapping):
+class CatalogCacheManager(object):
 	"""
 	Manager to handle cache information for catalogs
 	"""
 	def __init__(self, cache_file):
-		self._data = {}
 		self._cache_dict = {}
-		self._cache_cat = {}
-		self._cache_file = cache_file
+		self._data = {}
+		self._CatalogCacheEntry = collections.namedtuple('catalog', ['id', 'collections'])
+		self._CollectionCacheEntry = collections.namedtuple('collection', ['id', 'title', 'url', 'types'])
 
 		if os.path.isfile(cache_file):
 			with open(cache_file) as file_h:
@@ -633,16 +572,28 @@ class CatalogCacheManager(collections.MutableMapping):
 					self._cache_dict = json.load(file_h)
 				except ValueError:
 					self._cache_dict = {}
+			self._cache_file = cache_file
 
 		if not self._cache_dict or 'catalogs' not in self._cache_dict:
 			self._cache_dict['catalogs'] = {}
 		else:
 			cache_cat = self._cache_dict['catalogs']
 			for catalog_ in cache_cat:
-				self[catalog_] = CatalogCache(
+				self[catalog_] = self._CatalogCacheEntry(
 					cache_cat[catalog_]['id'],
-					cache_cat[catalog_]['repos']
+					self._tuple_collections(cache_cat[catalog_]['collections'])
 				)
+
+	def _tuple_collections(self, list_collections):
+		collections_ = []
+		for collection_ in list_collections:
+			collections_.append(self._CollectionCacheEntry(
+				collection_['id'],
+				collection_['title'],
+				collection_['url'],
+				collection_['types']
+			))
+		return collections_
 
 	def __setitem__(self, key, value):
 		self._data[key] = value
@@ -660,16 +611,21 @@ class CatalogCacheManager(collections.MutableMapping):
 		for key in self._data.keys():
 			yield key
 
-	def add_catalog_cache(self, cat_id, repos):
-		self[cat_id] = CatalogCache(
+	def add_catalog_cache(self, cat_id, collections_):
+		self[cat_id] = self._CatalogCacheEntry(
 			cat_id,
-			repos
+			self._tuple_collections(collections_)
 		)
 
 	def to_dict(self):
 		cache = {}
 		for key in self:
-			cache[key] = self._data[key].to_dict()
+			cache[key] = {}
+			cache[key]['id'] = self[key].id
+			collections_ = []
+			for collection_ in self[key].collections:
+				collections_.append(dict(collection_._asdict()))
+				cache[key]['collections'] = collections_
 		return cache
 
 	def save(self):
@@ -677,15 +633,17 @@ class CatalogCacheManager(collections.MutableMapping):
 		with open(self._cache_file, 'w+') as file_h:
 			json.dump(self._cache_dict, file_h, sort_keys=True, indent=4)
 
-class PluginCatalogManager(catalog.CatalogManager):
+class ClientCatalogManager(catalog.CatalogManager):
 	"""
 	Base manager for handling Catalogs
 	"""
 
-	def __init__(self, plugin_type, *args, **kwargs):
+	def __init__(self, manager_type=None, *args, **kwargs):
 		self._catalog_cache = CatalogCacheManager(os.path.join(DEFAULT_CONFIG_PATH, 'cache.json'))
-		super(PluginCatalogManager, self).__init__(*args, **kwargs)
-		self.manager_type = 'plugins/' + plugin_type
+		super(ClientCatalogManager, self).__init__(*args, **kwargs)
+		self.manager_type = 'plugins/client'
+		if manager_type:
+			self.manager_type = manager_type
 
 	def get_collection(self, catalog_id, repo_id):
 		"""
@@ -696,19 +654,19 @@ class PluginCatalogManager(catalog.CatalogManager):
 		:return: The the collection of manager type from the specified catalog and repository.
 		:rtype:py:class:
 		"""
-		if self.manager_type not in self.get_repo(catalog_id, repo_id).collections:
+		if self.manager_type not in self.get_repository(catalog_id, repo_id).collections:
 			return
-		return self.get_repo(catalog_id, repo_id).collections[self.manager_type]
+		return self.get_repository(catalog_id, repo_id).collections[self.manager_type]
 
 	def install_plugin(self, catalog_id, repo_id, plugin_id, install_path):
-		self.get_repo(catalog_id, repo_id).get_item_files(self.manager_type, plugin_id, install_path)
+		self.get_repository(catalog_id, repo_id).get_item_files(self.manager_type, plugin_id, install_path)
 
 	def save_catalog_cache(self):
 		for catalog_ in self.catalogs:
 			if catalog_ not in self._catalog_cache:
 				self._catalog_cache.add_catalog_cache(
 					self.catalogs[catalog_].id,
-					self.get_repos_to_cache(catalog_),
+					self.get_collections_to_cache(catalog_),
 				)
 		self._catalog_cache.save()
 
@@ -719,26 +677,15 @@ class PluginCatalogManager(catalog.CatalogManager):
 
 	def is_compatible(self, catalog_id, repo_id, plugin_name):
 		plugin = self.get_collection(catalog_id, repo_id)[plugin_name]
-		requirements = plugin['requirements']
-		if requirements['minimum-version'] is not None:
-			if StrictVersion(requirements['minimum-version']) > StrictVersion(version.distutils_version):
-				return False
-		if requirements['packages']:
-			if not all(self._package_check(requirements['packages'])):
-				return False
-		return True
+		return Requirements(plugin['requirements']).is_compatible
 
-	def _package_check(self, packages):
-		installed_packages = sorted(i.key for i in pip.get_installed_distributions())
-		for package in packages:
-			if package not in installed_packages:
-				yield False
-			else:
-				yield True
+	def compatibility(self, catalog_id, repo_id, plugin_name):
+		plugin = self.get_collection(catalog_id, repo_id)[plugin_name]
+		return Requirements(plugin['requirements']).compatibility
 
-	def get_repos_to_cache(self, catalog_):
+	def get_collections_to_cache(self, catalog_):
 		repo_cache_info = []
-		for repo in self.get_repos(catalog_):
+		for repo in self.get_repositories(catalog_):
 			repo_cache_info.append({
 				'id': repo.id,
 				'title': repo.title,
@@ -754,6 +701,6 @@ class PluginCatalogManager(catalog.CatalogManager):
 		for item in self._catalog_cache:
 			yield item
 
-	def get_cache_repos(self, catalog_id):
-		for repos in self._catalog_cache[catalog_id]:
-			yield repos
+	def get_cache_collections(self, catalog_id):
+		for collections_ in self._catalog_cache[catalog_id].collections:
+			yield collections_

--- a/king_phisher/client/plugins.py
+++ b/king_phisher/client/plugins.py
@@ -697,6 +697,5 @@ class ClientCatalogManager(catalog.CatalogManager):
 		for item in self._catalog_cache:
 			yield item
 
-	def get_cache_collections(self, catalog_id):
-		for collections_ in self._catalog_cache[catalog_id].collections:
-			yield collections_
+	def get_cache_repositories(self, catalog_id):
+		return iter(self._catalog_cache[catalog_id].repositories)

--- a/king_phisher/client/windows/plugin_manager.py
+++ b/king_phisher/client/windows/plugin_manager.py
@@ -30,17 +30,17 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-import sys
+import collections
 import os
+import sys
 import traceback
-
-from collections import namedtuple
 
 from king_phisher import utilities
 from king_phisher.client import application
 from king_phisher.client import gui_utilities
 from king_phisher.client.widget import managers
 from king_phisher.client.plugins import ClientCatalogManager
+
 from gi.repository import Gdk
 from gi.repository import Gtk
 
@@ -73,16 +73,27 @@ class PluginManagerWindow(gui_utilities.GladeGObject):
 		)
 	)
 	top_gobject = 'window'
-
+	_named_model = collections.namedtuple(
+		'model_row',
+		[
+			'id',
+			'installed',
+			'enabled',
+			'title',
+			'compatibility',
+			'version',
+			'visible_enabled',
+			'visible_installed',
+			'installed_sensitive',
+			'type'
+		]
+	)
 	def __init__(self, *args, **kwargs):
 		super(PluginManagerWindow, self).__init__(*args, **kwargs)
 		treeview = self.gobjects['treeview_plugins']
 		self.status_bar = self.gobjects['statusbar']
 		self._module_errors = {}
-		tvm = managers.TreeViewManager(
-			treeview,
-			cb_refresh=self._load_plugins
-		)
+		tvm = managers.TreeViewManager(treeview, cb_refresh=self._load_plugins)
 		toggle_renderer_enable = Gtk.CellRendererToggle()
 		toggle_renderer_enable.connect('toggled', self.signal_renderer_toggled_enable)
 		toggle_renderer_install = Gtk.CellRendererToggle()
@@ -103,28 +114,10 @@ class PluginManagerWindow(gui_utilities.GladeGObject):
 		tvm.column_views['Enabled'].add_attribute(toggle_renderer_enable, 'sensitive', 7)
 		tvm.column_views['Installed'].add_attribute(toggle_renderer_install, 'visible', 7)
 		tvm.column_views['Installed'].add_attribute(toggle_renderer_install, 'sensitive', 8)
-		self._named_model = namedtuple(
-			'model_row',
-			[
-				'id',
-				'installed',
-				'enabled',
-				'title',
-				'compatibility',
-				'version',
-				'visible_enabled',
-				'visible_installed',
-				'installed_sensitive',
-				'type'
-			]
-		)
 		self._model = Gtk.TreeStore(str, bool, bool, str, str, str, bool, bool, bool, str)
 		self._model.set_sort_column_id(1, Gtk.SortType.DESCENDING)
 		treeview.set_model(self._model)
 		self.plugin_path = os.path.join(application.USER_DATA_PATH, 'plugins')
-		if 'catalogs' not in self.config:
-			self.config['catalogs'] = ['https://raw.githubusercontent.com/securestate/king-phisher-plugins/dev/catalog.json']
-		self.catalog_list = self.config['catalogs']
 		self.load_thread = utilities.Thread(target=self._load_catalogs)
 		self.load_thread.start()
 		self.popup_menu = tvm.get_popup_menu()
@@ -136,7 +129,7 @@ class PluginManagerWindow(gui_utilities.GladeGObject):
 		menu_item_reload_all.connect('activate', self.signal_popup_menu_activate_reload_all)
 		self.popup_menu.append(menu_item_reload_all)
 		self.popup_menu.show_all()
-		self._update_status_bar('Loading: ')
+		self._update_status_bar('Loading...')
 		self.window.show()
 
 		selection = treeview.get_selection()
@@ -155,8 +148,8 @@ class PluginManagerWindow(gui_utilities.GladeGObject):
 	def _load_catalogs(self):
 		self._update_status_bar('Loading: Downloading Catalogs', idle=True)
 		self.catalog_plugins = ClientCatalogManager()
-		for catalog in self.catalog_list:
-			self.logger.debug("downloading catalog {}".format(catalog))
+		for catalog in self.config['plugins.catalogs']:
+			self.logger.debug("downloading catalog: {}".format(catalog))
 			self._update_status_bar("Loading: Downloading Catalog: {}".format(catalog))
 			self.catalog_plugins.add_catalog_url(catalog)
 		self._load_plugins()
@@ -171,10 +164,6 @@ class PluginManagerWindow(gui_utilities.GladeGObject):
 		else:
 			self.__update_status_bar(string_to_set)
 
-	def _model_item(self, model_path, item):
-		named_row = self._named_model(*self._model[model_path])
-		return getattr(named_row, item)
-
 	def _set_model_item(self, model_path, item, item_value):
 		self._model[model_path][self._named_model._fields.index(item)] = item_value
 
@@ -188,7 +177,11 @@ class PluginManagerWindow(gui_utilities.GladeGObject):
 			cell.set_property('inconsistent', False)
 
 	def _store_append(self, store, parent, model):
-		return store.append(parent, model)
+			return store.append(parent, model)
+
+	def _store_extend(self, store, parent, models):
+		for model in models:
+			store.append(parent, model)
 
 	def _load_plugins(self):
 		"""
@@ -196,7 +189,7 @@ class PluginManagerWindow(gui_utilities.GladeGObject):
 		visible to the user.
 		"""
 		self.logger.debug('loading plugins')
-		self._update_status_bar('Loading.... Plugins....', idle=True)
+		self._update_status_bar('Loading... Plugins...', idle=True)
 		store = self._model
 		store.clear()
 		pm = self.application.plugin_manager
@@ -204,22 +197,24 @@ class PluginManagerWindow(gui_utilities.GladeGObject):
 		pm.load_all(on_error=self._on_plugin_load_error)
 		model = ('local', None, True, '[Locally Installed]', None, None, False, False, False, 'Catalog')
 		catalog = gui_utilities.glib_idle_add_wait(self._store_append, store, None, model)
+		models = []
 		for name, plugin in pm.loaded_plugins.items():
 			if name in self.config['plugins.installed']:
 				continue
-			model = (
-				plugin.name,
-				True,
-				plugin.name in pm.enabled_plugins,
-				plugin.title,
-				'Yes' if plugin.is_compatible else 'No',
-				plugin.version,
-				True,
-				True,
-				False,
-				'Plugin'
-			)
-			gui_utilities.glib_idle_add_once(self._store_append, store, catalog, model)
+			models.append(self._named_model(
+				id=plugin.name,
+				installed=True,
+				enabled=plugin.name in pm.enabled_plugins,
+				title=plugin.title,
+				compatibility='Yes' if plugin.is_compatible else 'No',
+				version=plugin.version,
+				visible_enabled=True,
+				visible_installed=True,
+				installed_sensitive=False,
+				type='Plugin'
+			))
+			gui_utilities.glib_idle_add_once(self._store_append, store, catalog, models[-1])
+		del models
 
 		for name in self._module_errors.keys():
 			model = (name, True, False, "{0} (Load Failed)".format(name), 'unknown', True, True, False, 'Plugin')
@@ -238,10 +233,10 @@ class PluginManagerWindow(gui_utilities.GladeGObject):
 		else:
 			if not self.config['plugins.installed']:
 				return
-			for catalog_id in self.catalog_plugins.get_cache_catalog_ids():
+			for catalog_id, repositories in self.catalog_plugins.get_cache().items():
 				model = (catalog_id, None, True, "{} (offline)".format(catalog_id), None, None, False, False, False, 'Catalog (offline)')
 				catalog_line = gui_utilities.glib_idle_add_wait(self._store_append, store, None, model)
-				for repo in self.catalog_plugins.get_cache_repositories(catalog_id):
+				for repo in repositories:
 					model = (repo.id, None, True, "{} (offline)".format(repo.title), None, None, False, False, False, 'Repository (offline)')
 					repo_line = gui_utilities.glib_idle_add_wait(self._store_append, store, catalog_line, model)
 					self._add_plugins_offline(catalog_id, repo.id, store, repo_line)
@@ -250,46 +245,48 @@ class PluginManagerWindow(gui_utilities.GladeGObject):
 
 	def _add_plugins_to_tree(self, catalog, repo, store, parent, plugin_list):
 		client_plugins = list(plugin_list)
-		for plugins in client_plugins:
+		models = []
+		for plugin in client_plugins:
 			installed = False
 			enabled = False
-			if plugin_list[plugins]['name'] in self.config['plugins.installed']:
-				if repo.id == self.config['plugins.installed'][plugin_list[plugins]['name']][1]:
+			if plugin_list[plugin]['name'] in self.config['plugins.installed']:
+				if repo.id == self.config['plugins.installed'][plugin_list[plugin]['name']][1]:
 					installed = True
-					enabled = True if plugin_list[plugins]['name'] in self.config['plugins.enabled'] else False
-			model = (
-				plugins,
-				installed,
-				enabled,
-				plugin_list[plugins]['title'],
-				'Yes' if self.catalog_plugins.is_compatible(catalog, repo.id, plugins) else 'No',
-				self._get_version_or_upgrade(plugin_list[plugins]['name'], plugin_list[plugins]['version']),
-				True,
-				True,
-				True,
-				'Plugin'
-			)
-			gui_utilities.glib_idle_add_once(self._store_append, store, parent, model)
+					enabled = plugin_list[plugin]['name'] in self.config['plugins.enabled']
+			models.append(self._named_model(
+				id=plugin,
+				installed=installed,
+				enabled=enabled,
+				title=plugin_list[plugin]['title'],
+				compatibility='Yes' if self.catalog_plugins.is_compatible(catalog, repo.id, plugin) else 'No',
+				version=self._get_version_or_upgrade(plugin_list[plugin]['name'], plugin_list[plugin]['version']),
+				visible_enabled=True,
+				visible_installed=True,
+				installed_sensitive=True,
+				type='Plugin'
+			))
+		gui_utilities.glib_idle_add_once(self._store_extend, store, parent, models)
 
 	def _add_plugins_offline(self, catalog_id, repo_id, store, parent):
+		models = []
 		for plugin in self.config['plugins.installed']:
 			if self.config['plugins.installed'][plugin][0] != catalog_id:
 				continue
 			if self.config['plugins.installed'][plugin][1] != repo_id:
 				continue
-			model = (
-				plugin,
-				True,
-				True if plugin in self.config['plugins.enabled'] else False,
-				self.application.plugin_manager[plugin].title,
-				'Yes' if self.application.plugin_manager[plugin].is_compatible else 'No',
-				self.application.plugin_manager[plugin].version,
-				True,
-				True,
-				False,
-				'Plugin'
-			)
-			gui_utilities.glib_idle_add_once(self._store_append, store, parent, model)
+			models.append(self._named_model(
+				id=plugin,
+				installed=True,
+				enabled=plugin in self.config['plugins.enabled'],
+				title=self.application.plugin_manager[plugin].title,
+				compatibility='Yes' if self.application.plugin_manager[plugin].is_compatible else 'No',
+				version=self.application.plugin_manager[plugin].version,
+				visible_enabled=True,
+				visible_installed=True,
+				installed_sensitive=False,
+				type='Plugin'
+			))
+		gui_utilities.glib_idle_add_once(self._store_extend, store, parent, models)
 
 	def _get_version_or_upgrade(self, plugin_name, plugin_version):
 		if plugin_name not in self.application.plugin_manager:
@@ -304,7 +301,7 @@ class PluginManagerWindow(gui_utilities.GladeGObject):
 
 	def signal_destory(self, _):
 		if self.catalog_plugins:
-			self.catalog_plugins.save_catalog_cache()
+			self.catalog_plugins.save_cache()
 
 	def signal_treeview_row_activated(self, treeview, path, column):
 		self._set_plugin_info(self._model[path])
@@ -373,57 +370,59 @@ class PluginManagerWindow(gui_utilities.GladeGObject):
 			selected_plugin = model[tree_paths[0]][0]
 
 		for tree_iter in gui_utilities.gtk_treeview_selection_iterate(treeview):
-			if self._model_item(tree_iter, 'type') != 'Plugin':
+			named_row = self._named_model(*self._model[tree_iter])
+			if named_row.type != 'Plugin':
 				continue
-			plugin_id = self._model_item(tree_iter, 'id')
-			enabled = plugin_id in pm.enabled_plugins
-			pm.unload(plugin_id)
+			enabled = named_row.id in pm.enabled_plugins
+			pm.unload(named_row.id)
 			try:
-				klass = pm.load(plugin_id, reload_module=True)
+				klass = pm.load(named_row.id, reload_module=True)
 			except Exception as error:
-				self._on_plugin_load_error(plugin_id, error)
-				if plugin_id == selected_plugin:
-					self._set_plugin_info(plugin_id)
-				self._set_model_item(tree_iter, 'title', "{0} (Reload Failed)".format(plugin_id))
+				self._on_plugin_load_error(named_row.id, error)
+				if named_row.id == selected_plugin:
+					self._set_plugin_info(named_row.id)
+				self._set_model_item(tree_iter, 'title', "{0} (Reload Failed)".format(named_row.id))
 				continue
-			if plugin_id in self._module_errors:
-				del self._module_errors[plugin_id]
+			if named_row.id in self._module_errors:
+				del self._module_errors[named_row.id]
 			self._set_model_item(tree_iter, 'title', klass.title)
-			if plugin_id == selected_plugin:
-				self._set_plugin_info(plugin_id)
+			if named_row.id == selected_plugin:
+				self._set_plugin_info(named_row.id)
 			if enabled:
-				pm.enable(plugin_id)
+				pm.enable(named_row.id)
 
 	def signal_renderer_toggled_enable(self, _, path):
 		pm = self.application.plugin_manager
-		if self._model_item(path, 'type') != 'Plugin':
+		named_row = self._named_model(*self._model[path])
+		if named_row.type != 'Plugin':
 			return
-		if self._model_item(path, 'id') not in pm.loaded_plugins:
+		if named_row.id not in pm.loaded_plugins:
 			return
 		if self._model[path].parent:
-			installed_plugin_info = self.config['plugins.installed'][self._model_item(path, 'id')]
+			installed_plugin_info = self.config['plugins.installed'][named_row.id]
 			repo_model, catalog_model = self._get_plugin_model_parents(self._model[path])
 			if repo_model.id != installed_plugin_info[1] or catalog_model.id != installed_plugin_info[0]:
 				return
-		if self._model_item(path, 'id') in self._module_errors:
+		if named_row.id in self._module_errors:
 			gui_utilities.show_dialog_error('Can Not Enable Plugin', self.window, 'Can not enable a plugin which failed to load.')
 			return
-		if self._model_item(path, 'enabled'):
+		if named_row.enabled:
 			self._disable_plugin(path)
 		else:
-			if not pm.loaded_plugins[self._model_item(path, 'id')].is_compatible:
+			if not pm.loaded_plugins[named_row.id].is_compatible:
 				gui_utilities.show_dialog_error('Incompatible Plugin', self.window, 'This plugin is not compatible.')
 				return
-			if not pm.enable(self._model_item(path, 'id')):
+			if not pm.enable(named_row.id):
 				return
 			self._set_model_item(path, 'enabled', True)
-			self.config['plugins.enabled'].append(self._model_item(path, 'id'))
+			self.config['plugins.enabled'].append(named_row.id)
 
 	def signal_renderer_toggled_install(self, _, path):
 		repo_model, catalog_model = self._get_plugin_model_parents(self._model[path])
 		plugin_collection = self.catalog_plugins.get_collection(catalog_model.id, repo_model.id)
-		if self._model_item(path, 'installed'):
-			if self._model_item(path, 'enabled'):
+		named_row = self._named_model(*self._model[path])
+		if named_row.installed:
+			if named_row.enabled:
 				response = gui_utilities.show_dialog_yes_no(
 					'Plugin is enabled',
 					self.window,
@@ -433,10 +432,10 @@ class PluginManagerWindow(gui_utilities.GladeGObject):
 					return
 				self._disable_plugin(path)
 			self._uninstall_plugin(plugin_collection, path)
-			self.logger.info("uninstalled plugin {}".format(self._model_item(path, 'id')))
+			self.logger.info("uninstalled plugin {}".format(named_row.id))
 		else:
-			if self._model_item(path, 'id') in self.config['plugins.installed']:
-				installed_plugin_info = self.config['plugins.installed'][self._model_item(path, 'id')]
+			if named_row.id in self.config['plugins.installed']:
+				installed_plugin_info = self.config['plugins.installed'][named_row.id]
 				if installed_plugin_info != [catalog_model.id, repo_model.id]:
 					window_question = "A plugin with this name is already installed from Catalog: {} Repo: {}\nDo you want to replace it with this one?"
 					response = gui_utilities.show_dialog_yes_no(
@@ -447,38 +446,26 @@ class PluginManagerWindow(gui_utilities.GladeGObject):
 					if not response:
 						return
 					if not self._remove_matching_plugin(path, installed_plugin_info):
-						self.logger.warning('failed to uninstall plugin {}'.format(self._model_item(path, 'id')))
+						self.logger.warning('failed to uninstall plugin {}'.format(named_row.id))
 						return
-			self.catalog_plugins.install_plugin(
-				catalog_model.id,
-				repo_model.id,
-				self._model_item(path, 'id'),
-				self.plugin_path
-			)
-			self.config['plugins.installed'][self._model_item(path, 'id')] = [catalog_model.id, repo_model.id]
+			self.catalog_plugins.install_plugin(catalog_model.id, repo_model.id, named_row.id, self.plugin_path)
+			self.config['plugins.installed'][named_row.id] = [catalog_model.id, repo_model.id]
 			self._set_model_item(path, 'installed', True)
-			self._set_model_item(
-				path,
-				'version',
-				self.catalog_plugins.get_collection(catalog_model.id, repo_model.id)[self._model_item(path, 'id')]['version']
-			)
-			self.logger.info("installed plugin {} from catalog:{}, repository:{}".format(self._model_item(path, 'id'), catalog_model.id, repo_model.id))
+			self._set_model_item(path, 'version', self.catalog_plugins.get_collection(catalog_model.id, repo_model.id)[named_row.id]['version'])
+			self.logger.info("installed plugin {} from catalog:{}, repository:{}".format(named_row.id, catalog_model.id, repo_model.id))
 		self.application.plugin_manager.load_all(on_error=self._on_plugin_load_error)
 
-	def _disable_plugin(self, path, model_path=True):
-		if not model_path:
-			named_plugin = self._named_model(*path)
-			self.application.plugin_manager.disable(named_plugin.id)
-			self.config['plugins.enabled'].remove(named_plugin.id)
-			path[self._named_model._fields.index('enabled')] = False
-		else:
-			plugin_id = self._model_item(path, 'id')
-			self.application.plugin_manager.disable(plugin_id)
-			self.config['plugins.enabled'].remove(plugin_id)
+	def _disable_plugin(self, path, is_path=True):
+		named_row = self._named_model(*(self._model[path] if is_path else path))
+		self.application.plugin_manager.disable(named_row.id)
+		self.config['plugins.enabled'].remove(named_row.id)
+		if is_path:
 			self._set_model_item(path, 'enabled', False)
+		else:
+			path[self._named_model._fields.index('enabled')] = False
 
 	def _remove_matching_plugin(self, path, installed_plugin_info):
-		plugin_id = self._model_item(path, 'id')
+		named_row = self._named_model(*self._model[path])
 		for catalog_model in self._model:
 			if self._named_model(*catalog_model).id != installed_plugin_info[0]:
 				continue
@@ -487,15 +474,12 @@ class PluginManagerWindow(gui_utilities.GladeGObject):
 					continue
 				for plugin_model in repo_model.iterchildren():
 					named_model = self._named_model(*plugin_model)
-					if named_model.id != plugin_id:
+					if named_model.id != named_row.id:
 						continue
 					if named_model.enabled:
-						self._disable_plugin(plugin_model, model_path=False)
+						self._disable_plugin(plugin_model, is_path=False)
 					self._uninstall_plugin(
-						self.catalog_plugins.get_collection(
-							installed_plugin_info[0],
-							installed_plugin_info[1]
-						),
+						self.catalog_plugins.get_collection(installed_plugin_info[0], installed_plugin_info[1]),
 						plugin_model,
 						is_path=False
 					)
@@ -505,10 +489,7 @@ class PluginManagerWindow(gui_utilities.GladeGObject):
 		return self._named_model(*plugin_model.parent), self._named_model(*plugin_model.parent.parent)
 
 	def _uninstall_plugin(self, plugin_collection, path, is_path=True):
-		if is_path:
-			plugin_id = self._model_item(path, 'id')
-		else:
-			plugin_id = self._named_model(*path).id
+		plugin_id = self._named_model(*(self._model[path] if is_path else path)).id
 		for files in plugin_collection[plugin_id]['files']:
 			file_name = files[0]
 			if os.path.isfile(os.path.join(self.plugin_path, file_name)):
@@ -545,68 +526,51 @@ class PluginManagerWindow(gui_utilities.GladeGObject):
 			return
 		textview = self.gobjects['textview_plugin_info']
 		buf = textview.get_buffer()
-		text = ''
 		if named_model.type == 'Catalog':
 			instance_information = self.catalog_plugins.catalogs[named_model.id]
 		else:
-			instance_information = self.catalog_plugins.get_repository(self._named_model(*model_instance.parent).id, named_model.id)
+			instance_information = self.catalog_plugins.catalogs[self._named_model(*model_instance.parent).id].repositories[named_model.id]
 
-		text += "{0}\n".format(named_model.type)
+		text = "{0}\n".format(named_model.type)
 		text += "Title: {0}\n".format(getattr(instance_information, 'title', 'None'))
 		text += "Id: {0}\n".format(getattr(instance_information, 'id', 'None'))
 		text += "Description: {}\n".format(getattr(instance_information, 'description', 'None'))
-		if hasattr(instance_information, 'maintainers'):
-			text += 'Maintainer: ' + '\nMaintainer: '.join(getattr(instance_information, 'maintainers', ['None'])) + '\n'
-
-		buf.insert(buf.get_end_iter(), "{0}\n".format(text), -1)
+		if getattr(instance_information, 'maintainers', None):
+			text += 'Maintainer: ' + '\nMaintainer: '.join(instance_information.maintainers) + '\n'
+		buf.insert(buf.get_end_iter(), text, -1)
 
 	def _set_non_plugin_offline_info(self, model_instance):
 		named_model = self._named_model(*model_instance)
 		textview = self.gobjects['textview_plugin_info']
 		buf = textview.get_buffer()
-		text = '{0}\n'.format(named_model.type.split()[0])
-		text += "Title: {0}".format(named_model.title)
-		buf.insert(buf.get_end_iter(), "{0}\n".format(text), -1)
+		text = named_model.type.split()[0] + '\n'
+		text += "Title: {0}\n".format(named_model.title)
+		buf.insert(buf.get_end_iter(), text, -1)
 
 	def _set_plugin_info_details(self, plugin_model):
 		named_model = self._named_model(*plugin_model)
-		model_id = named_model.id
 		pm = self.application.plugin_manager
 		self._last_plugin_selected = plugin_model
-		if model_id in pm.loaded_plugins:
-			klass = pm.loaded_plugins[model_id]
-			self.gobjects['label_plugin_info_title'].set_text(klass.title)
-			self.gobjects['label_plugin_info_compatible'].set_text('Yes' if klass.is_compatible else 'No')
-			self.gobjects['label_plugin_info_version'].set_text(klass.version)
-			self.gobjects['label_plugin_info_authors'].set_text('\n'.join(klass.authors))
-			label_homepage = self.gobjects['label_plugin_info_homepage']
-			if klass.homepage is None:
-				label_homepage.set_property('visible', False)
-			else:
-				label_homepage.set_markup("<a href=\"{0}\">Homepage</a>".format(klass.homepage))
-				label_homepage.set_property('tooltip-text', klass.homepage)
-				label_homepage.set_property('visible', True)
-			self.gobjects['label_plugin_info_description'].set_text(klass.description)
+		if named_model.id in pm.loaded_plugins:
+			plugin = pm.loaded_plugins[named_model.id].metadata
+			is_compatible = plugin['is_compatible']
 		else:
 			repo_model, catalog_model = self._get_plugin_model_parents(plugin_model)
-			for repo in self.catalog_plugins.get_repositories(catalog_model.id):
-				if repo.id != repo_model.id:
-					continue
-				plugin = repo.collections['plugins/client'][named_model.id]
-				self.gobjects['label_plugin_info_title'].set_text(plugin['title'])
-				self.gobjects['label_plugin_info_compatible'].set_text(
-					'Yes' if self.catalog_plugins.is_compatible(catalog_model.id, repo_model.id, named_model.id) else 'No'
-				)
-				self.gobjects['label_plugin_info_version'].set_text(plugin['version'])
-				self.gobjects['label_plugin_info_authors'].set_text('\n'.join(plugin['authors']))
-				label_homepage = self.gobjects['label_plugin_info_homepage']
-				if plugin['homepage'] is None:
-					label_homepage.set_property('visible', False)
-				else:
-					label_homepage.set_markup("<a href=\"{0}\">Homepage</a>".format(plugin['homepage']))
-					label_homepage.set_property('tooltip-text', plugin['homepage'])
-					label_homepage.set_property('visible', True)
-				self.gobjects['label_plugin_info_description'].set_text(plugin['description'])
+			plugin = self.catalog_plugins.get_collection(catalog_model.id, repo_model.id)[named_model.id]
+			is_compatible = self.catalog_plugins.is_compatible(catalog_model.id, repo_model.id, named_model.id)
+
+		self.gobjects['label_plugin_info_title'].set_text(plugin['title'])
+		self.gobjects['label_plugin_info_compatible'].set_text('Yes' if is_compatible else 'No')
+		self.gobjects['label_plugin_info_version'].set_text(plugin['version'])
+		self.gobjects['label_plugin_info_authors'].set_text('\n'.join(plugin['authors']))
+		label_homepage = self.gobjects['label_plugin_info_homepage']
+		if plugin['homepage'] is None:
+			label_homepage.set_property('visible', False)
+		else:
+			label_homepage.set_markup("<a href=\"{0}\">Homepage</a>".format(plugin['homepage']))
+			label_homepage.set_property('tooltip-text', plugin['homepage'])
+			label_homepage.set_property('visible', True)
+		self.gobjects['label_plugin_info_description'].set_text(plugin['description'])
 
 	def _set_plugin_info_error(self, model_instance):
 		id_ = self._named_model(*model_instance).id

--- a/king_phisher/client/windows/plugin_manager.py
+++ b/king_phisher/client/windows/plugin_manager.py
@@ -31,17 +31,21 @@
 #
 
 import sys
+import os
 import traceback
 
 from king_phisher import utilities
 from king_phisher.client import gui_utilities
 from king_phisher.client.widget import managers
-from king_phisher import version
+from king_phisher.client.plugins import PluginCatalogManager
 
 from gi.repository import Gdk
 from gi.repository import Gtk
+from gi.repository import GLib
 
 __all__ = ('PluginManagerWindow',)
+
+DEFAULT_PLUGIN_PATH = os.path.join(GLib.get_user_config_dir(), 'king-phisher', 'plugins')
 
 class PluginManagerWindow(gui_utilities.GladeGObject):
 	"""
@@ -65,7 +69,8 @@ class PluginManagerWindow(gui_utilities.GladeGObject):
 			'stack_plugin_info',
 			'treeview_plugins',
 			'textview_plugin_info',
-			'viewport_plugin_info'
+			'viewport_plugin_info',
+			'statusbar'
 		)
 	)
 	top_gobject = 'window'
@@ -86,15 +91,25 @@ class PluginManagerWindow(gui_utilities.GladeGObject):
 		tvm.set_column_titles(
 			['Enabled', 'Installed', 'Type', 'Title', 'Compatible', 'Version'],
 			column_offset=1,
-			renderers=[toggle_renderer_enable, toggle_renderer_install, Gtk.CellRendererText(), Gtk.CellRendererText(), Gtk.CellRendererText(), Gtk.CellRendererText()]
+			renderers=[
+				toggle_renderer_enable,
+				toggle_renderer_install,
+				Gtk.CellRendererText(),
+				Gtk.CellRendererText(),
+				Gtk.CellRendererText(),
+				Gtk.CellRendererText()
+			]
 		)
 		tvm.column_views['Enabled'].set_cell_data_func(toggle_renderer_enable, self._toggle_cell_data_func)
-		#tvm.column_views['Installed'].set_cell_data_func(toggle_renderer_enable, self._toggle_cell_data_func)
 		tvm.column_views['Enabled'].add_attribute(toggle_renderer_enable, 'visible', 7)
-		tvm.column_views['Installed'].add_attribute(toggle_renderer_install, 'visible', 7)
-		self._model = Gtk.TreeStore(str, bool, bool, str, str, str, str, bool)
+		tvm.column_views['Installed'].add_attribute(toggle_renderer_install, 'visible', 8)
+		self._model = Gtk.TreeStore(str, bool, bool, str, str, str, str, bool, bool)
 		self._model.set_sort_column_id(2, Gtk.SortType.ASCENDING)
 		treeview.set_model(self._model)
+
+		#GLib.idle_add(self.gobjects['statusbar'].push, (0, 'Loading....'))
+
+		self.catalog_plugins = PluginCatalogManager('client', 'https://raw.githubusercontent.com/securestate/king-phisher-plugins/dev/catalog.json')
 		self.load_plugins()
 
 		self.popup_menu = tvm.get_popup_menu()
@@ -122,9 +137,6 @@ class PluginManagerWindow(gui_utilities.GladeGObject):
 		else:
 			cell.set_property('inconsistent', False)
 
-	def signal_popup_menu_activate_relaod_all(self, _):
-		self.load_plugins()
-
 	def load_plugins(self):
 		"""
 		Load the plugins which are available into the treeview to make them
@@ -136,25 +148,59 @@ class PluginManagerWindow(gui_utilities.GladeGObject):
 		self._module_errors = {}
 		pm.load_all(on_error=self._on_plugin_load_error)
 		#(parent (name, bool of check box, installed, type_name column, title column, compatible, version, bool if checkbox is visible))
-		catalog = store.append(None, ('catalog', True, None, 'Catalog', 'Manually Installed', None, None, False))
-		repo = store.append(catalog, ('repository', True, None, 'Repository', 'Local Paths', None, None, False))
 		for name, plugin in pm.loaded_plugins.items():
-			store.append(repo, (
+			if plugin.name in self.config['plugins.installed']:
+				continue
+			store.append(None, (
 				plugin.name,
 				plugin.name in pm.enabled_plugins,
 				True,
 				'Plugin',
 				plugin.title,
-				'Yes' if version.version >= plugin.req_min_version else 'No',
+				'Yes' if plugin.is_compatible else 'No',
 				plugin.version,
-				True
+				True,
+				False
 			))
+		for catalogs in self.catalog_plugins.catalog_ids():
+			catalog = store.append(None, (catalogs, True, None, 'Catalog', catalogs, None, None, False, False))
+			for repos in self.catalog_plugins.get_repos(catalogs):
+				repo = store.append(catalog, (repos.id, True, None, 'Repository', repos.title, None, None, False, False))
+				plugin_collections = self.catalog_plugins.get_collection(catalogs, repos.id)
+				client_plugins = list(plugin_collections)
+				client_plugins.sort()
+				for plugins in client_plugins:
+					installed = False
+					enabled = False
+					if plugin_collections[plugins]['name'] in self.config['plugins.installed']:
+						if repos.id == self.config['plugins.installed'][plugin_collections[plugins]['name']][1]:
+							installed = True
+							enabled = True if plugin_collections[plugins]['name'] in self.config['plugins.enabled'] else False
+					store.append(repo, (
+						plugin_collections[plugins]['name'],
+						enabled,
+						installed,
+						'Plugin',
+						plugin_collections[plugins]['title'],
+						'Unknown',
+						'N/A',
+						True,
+						True
+					))
 		for name in self._module_errors.keys():
 			store.append((
 				name,
 				False,
 				"{0} (Load Failed)".format(name)
 			))
+		#GLib.idle_add(self.gobjects['statusbar'].pop, 0)
+		#GLib.idle_add(self.gobjects['statusbar'].push, (0, 'Finished loading'))
+
+	def signal_popup_menu_activate_relaod_all(self, _):
+		self.load_plugins()
+
+	def signal_treeview_row_activated(self, treeview, path, column):
+		self._set_plugin_info(self._model[path])
 
 	def signal_label_activate_link(self, _, uri):
 		utilities.open_uri(uri)
@@ -233,16 +279,22 @@ class PluginManagerWindow(gui_utilities.GladeGObject):
 
 	def signal_renderer_toggled_enable(self, _, path):
 		pm = self.application.plugin_manager
-		name = self._model[path][0]  # pylint: disable=unsubscriptable-object
-		if not name or name in ['repo', 'catalog', 'repository']:
+		if self._model[path][3] != 'Plugin':
 			return
+		plugin_model = self._model[path]
+		name = self._model[path][0]  # pylint: disable=unsubscriptable-object
+		if name not in pm.loaded_plugins:
+			return
+		if name in self.config['plugins.installed']:
+			installed_plugin_info = self.config['plugins.installed'][name]
+			model_repo, model_cat = self._get_plugin_model_parents(self._model[path])
+			if model_repo[0] != installed_plugin_info[1] or model_cat[0] != installed_plugin_info[0]:
+				return
 		if name in self._module_errors:
 			gui_utilities.show_dialog_error('Can Not Enable Plugin', self.window, 'Can not enable a plugin which failed to load.')
 			return
 		if self._model[path][1]:  # pylint: disable=unsubscriptable-object
-			pm.disable(name)
-			self._model[path][1] = False # pylint: disable=unsubscriptable-object
-			self.config['plugins.enabled'].remove(name)
+			self._disable_plugin(plugin_model)
 		else:
 			if not pm.loaded_plugins[name].is_compatible:
 				gui_utilities.show_dialog_error('Incompatible Plugin', self.window, 'This plugin is not compatible.')
@@ -253,52 +305,155 @@ class PluginManagerWindow(gui_utilities.GladeGObject):
 			self.config['plugins.enabled'].append(name)
 
 	def signal_renderer_toggled_install(self, _, path):
-		pass
+		plugin_model = self._model[path]
+		repo_model, catalog_model = self._get_plugin_model_parents(plugin_model)
+		plugin_collection = self.catalog_plugins.get_collection(catalog_model[0], repo_model[0])
+		if plugin_model[2]:
+			if plugin_model[1]:
+				response = gui_utilities.show_dialog_yes_no(
+					'Plugin is enabled',
+					self.window,
+					"This will disable the plugin, do you wish to continue?"
+				)
+				if not response:
+					return
+				self._disable_plugin(plugin_model)
+			self.application.plugin_manager.unload(plugin_model[0])
+			self._uninstall_plugin(plugin_collection, plugin_model)
+			self.logger.info("uninstalled plugin {}".format(plugin_model[0]))
+		else:
+			if plugin_model[0] in self.config['plugins.installed']:
+				installed_plugin_info = self.config['plugins.installed'][plugin_model[0]]
+				if installed_plugin_info != [catalog_model[0], repo_model[0]]:
+					response = gui_utilities.show_dialog_yes_no(
+						'Plugin installed from another source',
+						self.window,
+						"A plugin with this name is already installed from Catalog: {} Repo: {}\nDo you want to replace it with this one?".format(installed_plugin_info[0], installed_plugin_info[1])
+					)
+					if not response:
+						return
+					if not self._remove_matching_plugin(plugin_model[0], installed_plugin_info):
+						self.logger.warning('failed to uninstall plugin {}'.format(plugin_model[0]))
+						return
+			self.catalog_plugins.install_plugin(catalog_model[0], repo_model[0], plugin_model[0], DEFAULT_PLUGIN_PATH)
+			self.config['plugins.installed'][plugin_model[0]] = [catalog_model[0], repo_model[0]]
+			plugin_model[2] = True
+			self.logger.info("installed plugin {} from catalog {}, repository {}".format(plugin_model[0], catalog_model[0], repo_model[0]))
+		self.application.plugin_manager.load_all(on_error=self._on_plugin_load_error)
 
-	def signal_treeview_row_activated(self, treeview, path, column):
-		name = self._model[path][0] # pylint: disable=unsubscriptable-object
-		self._set_plugin_info(name)
+	def _disable_plugin(self, plugin_model):
+		self.application.plugin_manager.disable(plugin_model[0])
+		self.config['plugins.enabled'].remove(plugin_model[0])
+		plugin_model[1] = False
 
-	def _set_plugin_info(self, name):
+	def _remove_matching_plugin(self, plugin_name, installed_plugin_info):
+		for catalog_model in self._model:
+			if catalog_model[0] != installed_plugin_info[0]:
+				continue
+			for repo_model in catalog_model.iterchildren():
+				if repo_model[0] != installed_plugin_info[1]:
+					continue
+				for plugin_model in repo_model.iterchildren():
+					if plugin_model[0] != plugin_name:
+						continue
+					if plugin_model[1]:
+						self._disable_plugin(plugin_model)
+					self._uninstall_plugin(self.catalog_plugins.get_collection(installed_plugin_info[0], installed_plugin_info[1]), plugin_model)
+					return True
+
+	def _get_plugin_model_parents(self, plugin_model):
+		return plugin_model.parent, plugin_model.parent.parent
+
+	def _uninstall_plugin(self, plugin_collection, plugin_model):
+		for files in plugin_collection[plugin_model[0]]['files']:
+			file_name = files[0]
+			if os.path.isfile(os.path.join(DEFAULT_PLUGIN_PATH, file_name)):
+				os.remove(os.path.join(DEFAULT_PLUGIN_PATH, file_name))
+		del self.config['plugins.installed'][plugin_model[0]]
+		plugin_model[2] = False
+
+	def _set_plugin_info(self, model_instance):
 		stack = self.gobjects['stack_plugin_info']
 		textview = self.gobjects['textview_plugin_info']
 		buf = textview.get_buffer()
 		buf.delete(buf.get_start_iter(), buf.get_end_iter())
-		if not name or name in ['repo', 'catalog', 'repository']:
+		name = model_instance[0]
+		if model_instance[3] != 'Plugin':
 			stack.set_visible_child(textview)
-			self._set_plugin_info_error(name)
+			self._set_non_plugin_info(model_instance)
 			return
-
 		if name in self._module_errors:
 			stack.set_visible_child(textview)
 			self._set_plugin_info_error(name)
 		else:
 			stack.set_visible_child(self.gobjects['grid_plugin_info'])
-			self._set_plugin_info_details(name)
+			self._set_plugin_info_details(model_instance)
 
-	def _set_plugin_info_details(self, name):
-		pm = self.application.plugin_manager
-		self._last_plugin_selected = name
-		klass = pm.loaded_plugins[name]
-		self.gobjects['label_plugin_info_title'].set_text(klass.title)
-		self.gobjects['label_plugin_info_compatible'].set_text('Yes' if klass.is_compatible else 'No')
-		self.gobjects['label_plugin_info_version'].set_text(klass.version)
-		self.gobjects['label_plugin_info_authors'].set_text('\n'.join(klass.authors))
-		label_homepage = self.gobjects['label_plugin_info_homepage']
-		if klass.homepage is None:
-			label_homepage.set_property('visible', False)
-		else:
-			label_homepage.set_markup("<a href=\"{0}\">Homepage</a>".format(klass.homepage))
-			label_homepage.set_property('tooltip-text', klass.homepage)
-			label_homepage.set_property('visible', True)
-		self.gobjects['label_plugin_info_description'].set_text(klass.description)
-
-	def _set_plugin_info_error(self, name):
+	def _set_non_plugin_info(self, model_instance):
 		textview = self.gobjects['textview_plugin_info']
 		buf = textview.get_buffer()
-		if not name or name in ['repo', 'catalog', 'repository']:
-			buf.insert(buf.get_end_iter(), "{}\n\nPlease Select Plugin".format(name))
-			return
+		text = ''
+		if model_instance[3] == 'Catalog':
+			instance_information = self.catalog_plugins.catalogs[model_instance[0]]
+		else:
+			instance_information = self.catalog_plugins.get_repo(model_instance.parent[0], model_instance[0])
+
+		if 'title' in dir(instance_information):
+			text += "Repository: {}\n".format(instance_information.title if instance_information.title else instance_information.id)
+		else:
+			text += "Catalog: {}\n".format(instance_information.id)
+
+		if 'maintainers' in dir(instance_information):
+			if instance_information.maintainers:
+				text += 'maintainer: ' + '\nmaintainer: '.join(instance_information.maintainers) + '\n'
+
+		if 'description' in dir(instance_information):
+			if instance_information.description:
+				text += instance_information.description + '\n'
+
+		buf.insert(buf.get_end_iter(), "{0}\n".format(text), -1)
+
+	def _set_plugin_info_details(self, plugin_model):
+		name = plugin_model[0]
+		pm = self.application.plugin_manager
+		self._last_plugin_selected = name
+		if name in pm.loaded_plugins:
+			klass = pm.loaded_plugins[name]
+			self.gobjects['label_plugin_info_title'].set_text(klass.title)
+			self.gobjects['label_plugin_info_compatible'].set_text('Yes' if klass.is_compatible else 'No')
+			self.gobjects['label_plugin_info_version'].set_text(klass.version)
+			self.gobjects['label_plugin_info_authors'].set_text('\n'.join(klass.authors))
+			label_homepage = self.gobjects['label_plugin_info_homepage']
+			if klass.homepage is None:
+				label_homepage.set_property('visible', False)
+			else:
+				label_homepage.set_markup("<a href=\"{0}\">Homepage</a>".format(klass.homepage))
+				label_homepage.set_property('tooltip-text', klass.homepage)
+				label_homepage.set_property('visible', True)
+			self.gobjects['label_plugin_info_description'].set_text(klass.description)
+		else:
+			repo_model, catalog_model = self._get_plugin_model_parents(plugin_model)
+			for repo in self.catalog_plugins.get_repos(catalog_model[0]):
+				if repo.id != repo_model[0]:
+					continue
+				plugin = repo.collections['plugins/client'][plugin_model[0]]
+				self.gobjects['label_plugin_info_title'].set_text(plugin['title'])
+				self.gobjects['label_plugin_info_compatible'].set_text('Fix ME Please') #fix me
+				self.gobjects['label_plugin_info_version'].set_text(plugin['version'])
+				self.gobjects['label_plugin_info_authors'].set_text('\n'.join(plugin['authors']))
+				label_homepage = self.gobjects['label_plugin_info_homepage']
+				if plugin['homepage'] is None:
+					label_homepage.set_property('visible', False)
+				else:
+					label_homepage.set_markup("<a href=\"{0}\">Homepage</a>".format(plugin['homepage']))
+					label_homepage.set_property('tooltip-text', plugin['homepage'])
+					label_homepage.set_property('visible', True)
+				self.gobjects['label_plugin_info_description'].set_text(plugin['description'])
+
+	def _set_plugin_info_error(self, model_instance):
+		name = model_instance[0]
+		textview = self.gobjects['textview_plugin_info']
+		buf = textview.get_buffer()
 		exc, formatted_exc = self._module_errors[name]
 		buf.insert(buf.get_end_iter(), "{0!r}\n\n".format(exc), -1)
 		buf.insert(buf.get_end_iter(), ''.join(formatted_exc), -1)

--- a/king_phisher/plugins.py
+++ b/king_phisher/plugins.py
@@ -172,7 +172,6 @@ class Requirements(_Mapping):
 			if package.startswith('gi.'):
 				if not importlib.util.find_spec(package):
 					missing_packages.append(package)
-				logging.info('During requirement check, gi subpackage was manually checked')
 				continue
 			package_check = smoke_zephyr.requirements.check_requirements([package])
 			if package_check:
@@ -251,6 +250,7 @@ class PluginBaseMeta(type):
 			'description': cls.description,
 			'homepage': cls.homepage,
 			'name': cls.name,
+			'is_compatible': cls.is_compatible,
 			'requirements': {
 				'minimum-version': cls.req_min_version,
 				'packages': tuple(cls.req_packages.keys())

--- a/king_phisher/plugins.py
+++ b/king_phisher/plugins.py
@@ -422,7 +422,7 @@ class PluginManagerBase(object):
 			recursive_reload(module)
 		return module
 
-	def unload(self, name):
+	def PluginBaseMeta(self, name):
 		"""
 		Unload a plugin from memory. If the specified plugin is currently
 		enabled, it will first be disabled before being unloaded. If the plugin

--- a/king_phisher/utilities.py
+++ b/king_phisher/utilities.py
@@ -489,13 +489,16 @@ class Thread(threading.Thread):
 	King Phishers base threading class with two way event.
 	"""
 	logger = logging.getLogger('KingPhisher.Thread')
-	def __init__(self, *args, **kwargs):
-		super(Thread, self).__init__(*args, **kwargs)
+	def __init__(self, target=None, name=None, args=(), kwargs={}, **_kwargs):
+		super(Thread, self).__init__(target=target, name=name, args=args, kwargs=kwargs, **_kwargs)
+		self.target_name = None
+		if target is not None:
+			self.target_name = target.__module__ + '.' + target.__name__
 		self.stop_flag = Event()
 		self.stop_flag.clear()
 
 	def run(self):
-		self.logger.debug("thread {0} running in tid: 0x{1:x}".format(self.name, threading.current_thread().ident))
+		self.logger.debug("thread {0} running {1} in tid: 0x{2:x}".format(self.name, self.target_name, threading.current_thread().ident))
 		super(Thread, self).run()
 
 	def stop(self):

--- a/king_phisher/utilities.py
+++ b/king_phisher/utilities.py
@@ -488,10 +488,9 @@ class Thread(threading.Thread):
 	"""
 	King Phishers base threading class with two way event.
 	"""
-
+	logger = logging.getLogger('KingPhisher.Thread')
 	def __init__(self, *args, **kwargs):
 		super(Thread, self).__init__(*args, **kwargs)
-		self.logger = logging.getLogger('KingPhisher.Thread.{0}'.format(self.name))
 		self.stop_flag = Event()
 		self.stop_flag.clear()
 
@@ -501,7 +500,7 @@ class Thread(threading.Thread):
 
 	def stop(self):
 		"""
-		Sets the flag to signal the threat to stop.
+		Sets the flag to signal the thread to stop.
 		"""
 		self.stop_flag.set()
 


### PR DESCRIPTION
# First Review of Plugin Store Manager
This PR for review consist of the below phases of the plugin store project
- Phase 1.2
- Phase 1.3

- [ ] Loads KingPhisher's Plugin Catalog
- [ ] Can install plugins from the catalog
  - [ ] If you install a plugin with same name from another repo/catalog it will inform you that you will over write current plugin, and ask if you want to continue
- [ ] Can enable freshly installed plugins from a catalog
- [ ] Can Disable a plugin belonging to a catalog
- [ ] Will display plugins belonging to catalog , when in Client cannot pull catalog information
- [ ] Displays information of plugin belonging to catalog
  - *NOTE* if you click on compatibility in information pan to display what is missing it will stack trace (Next on to do list)
- [ ] Version of catalog plugins will change to `Upgrade available` if installed version is < then catalog available version.
- [ ] Installing a plugin that has an Upgrade available will change version to reflect new installed version.

Phase 1.4 is next where end user can add custom catalogs to the store.