### PR TITLE
Change how the pip arguments list is built

### DIFF
--- a/king_phisher/plugins.py
+++ b/king_phisher/plugins.py
@@ -623,15 +623,15 @@ class PluginManagerBase(object):
 		:return: The process results from the command execution.
 		:rtype: :py:class:`~.ProcessResults`
 		"""
-		options = []
+		pip_options = []
 		if self.library_path is None:
 			raise errors.KingPhisherResourceError('missing plugin-specific library path')
-		options.extend(['--target', self.library_path])
+		pip_options.extend(['--target', self.library_path])
 		if its.frozen:
-			executable_path = os.path.dirname(sys.executable)
-			args = [os.path.join(executable_path, 'python.exe'), '-m', 'pip', 'install'] + options + packages
+			args = [os.path.join(os.path.dirname(sys.executable), 'python.exe')]
 		else:
-			args = [sys.executable, '-m', 'pip', 'install'] + options + packages
+			args = [sys.executable] + pip_options + packages
+		args += ['-m', 'pip', 'install'] + pip_options + packages
 		if len(packages) > 1:
 			info_string = "installing packages: {}"
 		else:


### PR DESCRIPTION
This change consolidates the arguments to Python into a single location and renames the options list to `pip_options` so we know what options those are.